### PR TITLE
Add optional `poll_mode` to control ES.GetMode polling

### DIFF
--- a/custom_components/marstek_local_api/__init__.py
+++ b/custom_components/marstek_local_api/__init__.py
@@ -43,6 +43,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         dod_percent=entry.options.get("dod_percent", DOD_DEFAULT),
         medium_interval_secs=entry.options.get("medium_interval_secs", UPDATE_INTERVAL_MEDIUM_SECS),
         slow_interval_secs=entry.options.get("slow_interval_secs", UPDATE_INTERVAL_SLOW_SECS),
+        poll_mode=entry.options.get("poll_mode", True),
     )
 
     # Check if this is a multi-device or single-device entry

--- a/custom_components/marstek_local_api/config_flow.py
+++ b/custom_components/marstek_local_api/config_flow.py
@@ -456,6 +456,10 @@ class OptionsFlow(config_entries.OptionsFlow):
                         "slow_interval_secs",
                         default=opts.get("slow_interval_secs", UPDATE_INTERVAL_SLOW_SECS),
                     ): NumberSelector(NumberSelectorConfig(min=300, max=86400, mode=NumberSelectorMode.BOX)),
+                    vol.Optional(
+                        "poll_mode",
+                        default=opts.get("poll_mode", True),
+                    ): cv.boolean,
                 }
             ),
         )

--- a/custom_components/marstek_local_api/const.py
+++ b/custom_components/marstek_local_api/const.py
@@ -5,6 +5,7 @@ DOMAIN: Final = "marstek_local_api"
 
 # Configuration keys
 CONF_PORT: Final = "port"
+CONF_POLL_MODE: Final = "poll_mode"
 
 # Default values
 DEFAULT_PORT: Final = 30000

--- a/custom_components/marstek_local_api/coordinator.py
+++ b/custom_components/marstek_local_api/coordinator.py
@@ -44,6 +44,7 @@ class CoordinatorConfig:
     dod_percent: int = DOD_DEFAULT
     medium_interval_secs: int = UPDATE_INTERVAL_MEDIUM_SECS
     slow_interval_secs: int = UPDATE_INTERVAL_SLOW_SECS
+    poll_mode: bool = True
 
 
 class MarstekMultiDeviceCoordinator(DataUpdateCoordinator):
@@ -71,6 +72,7 @@ class MarstekMultiDeviceCoordinator(DataUpdateCoordinator):
         self.dod_percent = cfg.dod_percent
         self.medium_interval_secs = cfg.medium_interval_secs
         self.slow_interval_secs = cfg.slow_interval_secs
+        self.poll_mode = cfg.poll_mode
 
         super().__init__(
             hass,
@@ -641,7 +643,7 @@ class MarstekDataUpdateCoordinator(DataUpdateCoordinator):
                     had_success = True
 
             # Medium priority (continued) - ES.GetMode
-            if run_medium:
+            if run_medium and self.poll_mode:
                 try:
                     await asyncio.sleep(_command_delay())  # Delay between API calls
                     mode_status = await self.api.get_es_mode(**_command_kwargs())

--- a/custom_components/marstek_local_api/translations/en.json
+++ b/custom_components/marstek_local_api/translations/en.json
@@ -55,7 +55,8 @@
           "command_min_interval": "Minimum interval between frames (seconds)",
           "stale_data_threshold": "Stale data threshold (seconds)",
           "medium_interval_secs": "Medium update interval (seconds)",
-          "slow_interval_secs": "Slow update interval (seconds)"
+          "slow_interval_secs": "Slow update interval (seconds)",
+          "poll_mode": "Poll operating mode (ES.GetMode)"
         },
         "data_description": {
           "scan_interval": "Base polling interval for real-time sensors (ES, EM, PV).",
@@ -64,7 +65,8 @@
           "command_min_interval": "Minimum time (in seconds) between two consecutive frames sent to the battery. Increase if the device struggles with rapid commands (e.g. during mode changes). Default: 0.5 s.",
           "stale_data_threshold": "How old data can be (in seconds) before entities show as unavailable. Recommended: at least twice the slow update interval (default: 2 × 1200 = 2400 s). Default: 3600 s (1 hour).",
           "medium_interval_secs": "How often battery status and operating mode are polled (Bat.GetStatus, ES.GetMode). Default: 300 s (5 min).",
-          "slow_interval_secs": "How often static device info is polled (device, Wi-Fi, BLE). Default: 1200 s (20 min)."
+          "slow_interval_secs": "How often static device info is polled (device, Wi-Fi, BLE). Default: 1200 s (20 min).",
+          "poll_mode": "When enabled, Home Assistant polls the device for operating mode via ES.GetMode on the medium interval. Disable if you observe unexpected configuration resets when ES.GetMode is polled. Default: enabled."
         }
       },
       "battery_settings": {


### PR DESCRIPTION
Users [reported](https://github.com/jaapp/ha-marstek-local-api/issues/111) device resets on Marstek Venus devices with firmware V148. In that [linked issue](https://github.com/jaapp/ha-marstek-local-api/issues/111), another user troubleshooted and found that this correlated with `ES.GetMode` polling. 

Making this polling optional lets users disable it while preserving other important telemetry.

Summary
- Add a configurable option `poll_mode` (default: true) to control whether the coordinator performs `ES.GetMode` on the medium polling tier.

What changed
- `custom_components/marstek_local_api/const.py`: added `CONF_POLL_MODE`.
- `custom_components/marstek_local_api/config_flow.py`: exposed `poll_mode` in the options UI.
- `custom_components/marstek_local_api/__init__.py`: pass `poll_mode` from entry options into `CoordinatorConfig`.
- `custom_components/marstek_local_api/coordinator.py`: added `poll_mode` to `CoordinatorConfig`, initialize per-coordinator, and guard `ES.GetMode` with `if run_medium and self.poll_mode:` so disabling prevents the medium-tier `ES.GetMode` call.
- `custom_components/marstek_local_api/translations/en.json`: added option strings and description.

Behavior when `poll_mode` is disabled: only `ES.GetMode` calls are suppressed. 
Other high-priority (every update) calls remain unchanged.

- Practical effect:
  - Operating mode (`mode`) will not be refreshed by `ES.GetMode` and will remain at the last value the integration received (stale) until either `poll_mode` is re-enabled, a slow-tier device-info refresh returns mode, or another API call yields that value (?).
  - Grid power in/out (and other values returned by `ES.GetStatus`) remain fresh (high-priority). Battery power (bat_power) and PV power remain fresh from `ES.GetStatus`/`PV.GetStatus` as applicable.
  - Battery SOC and other battery-specific fields (bat_capacity, soc) are sourced from `Bat.GetStatus` which is polled at the medium interval — disabling `poll_mode` doesn't stop these medium-tier battery requests.